### PR TITLE
do not unnecessarily flush or destroy

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,10 +40,11 @@ template '/usr/sbin/rebuild-ipset' do
   )
 end
 
-template '/etc/network/if-pre-up.d/00-ipset_load' do
-  source 'ipset_load.erb'
+file '/etc/network/if-pre-up.d/00-ipset_load' do
+  content <<-EOF
+    #!/bin/sh
+    /usr/sbin/rebuild-ipset
+    exit 0
+  EOF
   mode '0755'
-  variables(
-    ipset_save_file: '/etc/ipset/ipset-generated'
-  )
 end

--- a/templates/default/entry.erb
+++ b/templates/default/entry.erb
@@ -1,1 +1,1 @@
-add <%= @set %> <%= @entry %> <%= options_to_s(@options) %> comment "<%= @comment %>"
+add <%= @set %> <%= @entry %> <%= options_to_s(@options) %> comment "<%= @comment %>" -exist

--- a/templates/default/ipset_load.erb
+++ b/templates/default/ipset_load.erb
@@ -1,3 +1,0 @@
-#!/bin/sh
-/sbin/ipset restore -file <%= @ipset_save_file %>
-exit 0

--- a/templates/default/rebuild-ipset.erb
+++ b/templates/default/rebuild-ipset.erb
@@ -21,6 +21,10 @@
 SETS_D = "/etc/ipset/sets.d/"
 OUTPUT = "/etc/ipset/ipset-generated"
 
+def current_sets
+  output = `/sbin/ipset list`
+  output.each_line.select { |l| l.include?('Name: ') }.map { |l| l.gsub('Name: ', '').strip }
+end
 
 def write_ipset(file, data)
   File.open("#{file}.new", "w") { |f| f.write(data) }
@@ -48,9 +52,6 @@ def generate_ipset
   EOS
 
   data << "\n"
-  data << "flush\n"
-  data << "destroy\n"
-  data << "\n"
 
   Dir.foreach(SETS_D) do |e|
     set_file = File.join(SETS_D, e)
@@ -64,6 +65,14 @@ def generate_ipset
   data
 end
 
+def clean_sets(new_sets_commands, current_sets)
+  current_sets.each do |set|
+    unless new_sets_commands.include?("create #{set}")
+      exit $?.exitstatus unless system("/sbin/ipset destroy #{set} -exist")
+    end
+  end
+end
 
-load_ipset(generate_ipset)
-exit $?.exitstatus
+new_sets_commands = generate_ipset
+load_ipset(new_sets_commands)
+clean_sets(new_sets_commands, current_sets)

--- a/templates/default/set.erb
+++ b/templates/default/set.erb
@@ -1,5 +1,5 @@
-create <%= @name %> <%= @type %> comment <%= options_to_s(@options) %>
+create <%= @name %> <%= @type %> comment <%= options_to_s(@options) %> -exist
 
 <% @entries.each_pair do |entry, entry_options| -%>
-add <%= @name %> <%= entry %> <%= options_to_s(entry_options) %>
+add <%= @name %> <%= entry %> <%= options_to_s(entry_options) %> -exist
 <% end -%>


### PR DESCRIPTION
rel: https://github.com/Shopify/cookbooks/pull/11545

According to `ipset` documentation `ipset` is expected to do nothing when `ipset destroy` command can not destroy a set. But it actually returns error and this breaks `ipset-cookbooks` because in every run it tries to destroy all sets and recreates them. But because `destroy` command returns error the create commands never gets executed. This PR separates `destroy` action from `create` action and instead of destroying everything it destroys only the sets that marked as `to remove(i.e ipset with remove action)` in the recipe.

/r @mredan 
@Shopify/traffic 
